### PR TITLE
Include NSGA-III ans SPEA-II as optimisation algorithms

### DIFF
--- a/docs/sphinx/optimization.rst
+++ b/docs/sphinx/optimization.rst
@@ -35,6 +35,7 @@ To characterize and configure a deterministic design optimization, the following
                 'mut prob':            mut_prob,               #optional, default is 0.1
                 'eta':                 eta,                    #optional, default is 0.2
                 'n jobs':              n_jobs,                 #optional, default is 1 
+				'algo':                algo,                   #optional, default is 'NSGA2' 
                 }
 
 This dictionary is used as the argument for the :py:func:`run_opt()` function, 
@@ -235,6 +236,23 @@ Alternatively, the number of parallel processes can be retreived through the :py
 After importing multiprocessing, the item can be defined by::
 
     'n jobs': int(multiprocessing.cpu_count()/2)
+	
+'algo': algo
+~~~~~~~~~~~~~~~~
+
+The optimisation algorithm. 
+NSGA-II is employed by default (more information in :ref:`lab:ssnsga2`)::
+
+	'algo': 'NSGA2'
+	
+Alternatively, NSGA-III and SPEA-II can also be used.
+The item can be defined by::
+
+    'algo': 'NSGA3'
+	
+or by::
+
+	'algo': 'SPEA2'
 
 Example of a dictionary for deterministic design optimization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/rheia/CASES/determine_stoch_des_space.py
+++ b/rheia/CASES/determine_stoch_des_space.py
@@ -76,6 +76,7 @@ def check_dictionary(run_dict, uq_bool=False):
                          'cx prob',
                          'mut prob',
                          'eta',
+                         'algo',
                          ]
 
         if 'x0' not in run_dict:
@@ -93,6 +94,8 @@ def check_dictionary(run_dict, uq_bool=False):
         if 'eta' not in run_dict:
             run_dict['eta'] = 0.2
             warnings.warn("The eta parameter is defined automatically at 0.2")
+        if 'algo' not in run_dict:
+            run_dict['algo'] = 'NSGA2'
 
         for key in requirements[3:]:
             try:

--- a/rheia/OPT/optimization.py
+++ b/rheia/OPT/optimization.py
@@ -320,7 +320,7 @@ def run_opt(run_dict, design_space='design_space.csv'):
     run_dict['evaluate'] = eval_func
 
     # load optimizer class
-    opt_class = load_optimizer('NSGA2')
+    opt_class = load_optimizer(run_dict['algo'])
 
     # check if previous results in this result directory exist
     start_from_last_gen = check_existing_results(run_dict, space_obj)


### PR DESCRIPTION
Gives the possibility to choose new algorithms when launching an optimisation task. Basically, two new classes (`NSGA3(NSGA2)` and `SPEA2(NSGA2)`), inheriting from `NSGA2`, where added to `genetic_algorithms.py`.  These use the `selNSGA3` and `selSPEA2` functions from the [DEAP package](https://deap.readthedocs.io/en/master/index.html#). Accordingly, `optimization.py` and `determine_stoch_des_space.py` have been adapted. The documentation was updated in `optimization.rst`.